### PR TITLE
fix(transcripts): preserve split session identities

### DIFF
--- a/docs/JOURNAL_SCHEMA.md
+++ b/docs/JOURNAL_SCHEMA.md
@@ -71,6 +71,10 @@ python scripts/generate_journal_indexes.py --journal ../ActiveInferenceJournal -
 `INDEX.json` contains `count`, `videos` (part records, including deliberate duplicates),
 `unique_videos`, and item records.
 
+Split-file transcript records use their session identity (`<video_id>_sessNN`) in both
+the `transcript.txt` headings and `transcript.json` `video_id` fields. Repair derived
+outputs with `scripts/repair_split_transcripts.py` when source session pairs are present.
+
 ## Top-level
 
 - `INDEX.json` — machine index: every item + parts + paths + flags, including record and

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,3 +108,13 @@ python scripts/generate_journal_indexes.py --journal ../ActiveInferenceJournal -
 `enrich_metadata.py` is dry-run by default and preserves journal-owned
 `sessions[]`. `generate_journal_indexes.py` derives `INDEX.json` and `INDEX.md`
 from canonical metadata, including duplicate and unique-video counts.
+
+For split-file items whose merged transcript sections need rebuilding:
+
+```bash
+python scripts/repair_split_transcripts.py --journal ../ActiveInferenceJournal --utilities .
+python scripts/repair_split_transcripts.py --journal ../ActiveInferenceJournal --utilities . --check
+```
+
+The repair is idempotent and writes only when complete `<video_id>_sessNN`
+source pairs are available.

--- a/scripts/refactor_journal.py
+++ b/scripts/refactor_journal.py
@@ -139,6 +139,7 @@ def _video_id(name: str) -> str:
     stem = re.sub(r"\.(simple\.)?(json|txt|srt)$", "", name)
     m = (
         re.search(r"\[([A-Za-z0-9_-]{11})\]", stem)  # symposium: "... [hW9IiOujS1E]_0"
+        or re.search(r"^([A-Za-z0-9_-]{11})_sess\d+\b", stem)
         or re.search(r"_youtube_([A-Za-z0-9_-]{11})\b", stem)
         or re.search(r"_([A-Za-z0-9_-]{11})$", stem)
         or re.search(r"_([A-Za-z0-9_-]{11})\b", stem)
@@ -368,7 +369,7 @@ def main() -> int:
         return 0
 
     plan = analyze(journal)
-    print(f"=== ActiveInferenceJournal v2 refactor — DRY RUN ===")
+    print("=== ActiveInferenceJournal v2 refactor — DRY RUN ===")
     print(f"journal: {journal}")
     print(f"items: {plan['items']}   total files: {plan['total_files']}")
     print("by category:")

--- a/scripts/repair_split_transcripts.py
+++ b/scripts/repair_split_transcripts.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Repair merged v2 transcripts built from session-split source files.
+
+Some multi-session items were refactored with blank section IDs because source
+files named ``<video_id>_sessNN`` were not recognized as belonging to their
+parent video.  This command uses the canonical item's ``sessions[]`` records
+and Journal-Utilities' split outputs to rebuild only the affected TXT/JSON
+artifacts.
+
+Usage:
+    python scripts/repair_split_transcripts.py \
+        --journal ../ActiveInferenceJournal \
+        --utilities .
+    python scripts/repair_split_transcripts.py \
+        --journal ../ActiveInferenceJournal --utilities . --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_PREFIX = Path("data/video/activeinferenceinstitute")
+
+
+def _session_sources(session_names: list[str], utilities: Path) -> tuple[str, str] | None:
+    """Render a merged transcript from complete split-file outputs."""
+    text_sections: list[str] = []
+    json_records: list[dict] = []
+    output = utilities / "data/output"
+    for session_name in session_names:
+        text_path = output / f"{session_name}.simple.txt"
+        json_path = output / f"{session_name}.json"
+        if not text_path.is_file() or not json_path.is_file():
+            return None
+        try:
+            segments = json.loads(json_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid session JSON: {json_path}: {exc}") from exc
+        if not isinstance(segments, list):
+            raise ValueError(f"session JSON must contain a segment list: {json_path}")
+        text = text_path.read_text(encoding="utf-8", errors="replace").strip()
+        if not text:
+            raise ValueError(f"session transcript is empty: {text_path}")
+        text_sections.append(f"## {session_name}\n\n{text}")
+        json_records.append({"video_id": session_name, "segments": segments})
+    return "\n\n".join(text_sections) + "\n", json.dumps(json_records, ensure_ascii=False)
+
+
+def repair_item(item_dir: Path, utilities: Path, check: bool = False) -> bool:
+    """Repair one item and return whether its derived files were stale."""
+    metadata_path = item_dir / "metadata.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    session_names = [
+        session["session_name"]
+        for session in sorted(metadata.get("sessions", []), key=lambda entry: entry.get("index", 0))
+        if session.get("session_name")
+    ]
+    if not session_names:
+        return False
+    rendered = _session_sources(session_names, utilities)
+    if rendered is None:
+        return False
+    text, structured = rendered
+    targets = ((item_dir / "transcript.txt", text), (item_dir / "transcript.json", structured))
+    stale = any(
+        not path.is_file() or path.read_text(encoding="utf-8") != expected
+        for path, expected in targets
+    )
+    if stale and not check:
+        for path, expected in targets:
+            path.write_text(expected, encoding="utf-8")
+        print(f"updated: {item_dir}")
+    elif stale:
+        print(f"stale: {item_dir}")
+    return stale
+
+
+def repair_journal(journal: Path, utilities: Path, check: bool = False) -> bool:
+    """Repair every v2 item with complete split-file sources."""
+    stale = False
+    for metadata_path in sorted((journal / SRC_PREFIX).rglob("metadata.json")):
+        stale = repair_item(metadata_path.parent, utilities, check) or stale
+    return stale
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--journal", type=Path, required=True)
+    parser.add_argument("--utilities", type=Path, required=True)
+    parser.add_argument(
+        "--check", action="store_true", help="fail when a derived transcript is stale"
+    )
+    args = parser.parse_args()
+    journal = args.journal.resolve()
+    utilities = args.utilities.resolve()
+    if not (journal / SRC_PREFIX).is_dir():
+        print(f"journal source root not found: {journal / SRC_PREFIX}", file=sys.stderr)
+        return 1
+    return int(repair_journal(journal, utilities, args.check) and args.check)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/journal_utilities/test_transcript_repair.py
+++ b/tests/journal_utilities/test_transcript_repair.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from scripts.refactor_journal import _video_id
+from scripts.repair_split_transcripts import _session_sources, repair_item
+
+
+def test_video_id_recognizes_session_split_filename():
+    assert _video_id("cIBIecj7UZE_sess01.simple.txt") == "cIBIecj7UZE"
+
+
+def test_session_sources_preserve_session_identity(tmp_path: Path):
+    output = tmp_path / "data/output"
+    output.mkdir(parents=True)
+    (output / "video123456_sess01.simple.txt").write_text("First", encoding="utf-8")
+    (output / "video123456_sess01.json").write_text(
+        '[{"start": 0, "text": "First"}]', encoding="utf-8"
+    )
+    rendered = _session_sources(["video123456_sess01"], tmp_path)
+    assert rendered is not None
+    text, structured = rendered
+    assert text == "## video123456_sess01\n\nFirst\n"
+    assert json.loads(structured)[0]["video_id"] == "video123456_sess01"
+
+
+def test_repair_item_is_idempotent(tmp_path: Path):
+    utilities = tmp_path / "utilities"
+    output = utilities / "data/output"
+    output.mkdir(parents=True)
+    session = "video123456_sess01"
+    (output / f"{session}.simple.txt").write_text("First", encoding="utf-8")
+    (output / f"{session}.json").write_text("[]", encoding="utf-8")
+
+    item = tmp_path / "journal/data/video/activeinferenceinstitute/Series/item"
+    item.mkdir(parents=True)
+    (item / "metadata.json").write_text(
+        json.dumps({"sessions": [{"index": 1, "session_name": session}]}), encoding="utf-8"
+    )
+    assert repair_item(item, utilities)
+    assert not repair_item(item, utilities, check=True)


### PR DESCRIPTION
Fix session-split transcript identity loss: recognize <video_id>_sessNN source filenames during refactor, add an idempotent repair_split_transcripts.py command, document it, and add regression tests. Validation: 35 focused tests pass; Ruff passes for the new repair code/tests; the repaired 2024 symposium artifacts have no blank headings or empty video_id fields.