### PR TITLE
Categorizer: Fundamentals reading group → TextbookGroup/Namjoshi2026

### DIFF
--- a/data/output/channel_videos.json
+++ b/data/output/channel_videos.json
@@ -1,7 +1,7 @@
 {
   "channel_id": "UCbPq2w41ZaJSWtpCq4BE6Dg",
   "channel_url": "https://www.youtube.com/channel/UCbPq2w41ZaJSWtpCq4BE6Dg",
-  "enumerated_at": "2026-07-17T19:15:24.470076+00:00",
+  "enumerated_at": "2026-07-17T19:32:59.839526+00:00",
   "total_videos": 735,
   "videos": [
     {

--- a/src/journal_utilities/youtube/categorizer.py
+++ b/src/journal_utilities/youtube/categorizer.py
@@ -58,6 +58,7 @@ YOUTUBE_TITLE_PATTERNS = {
     'reviewstream': r'(ReviewStream|Active Inference Livestream Review)',
     'roundtable': r'(ActInfLab|Active Inference Institute).*?(\d{4}).*?Quarterly Roundtable #(\d+)',
     'textbookgroup': r'ActInf Textbook Group ~ Cohort (\d+) ~ (?:Meeting|Session) (\d+)',
+    'fundamentals': r'Fundamentals of Active Inference.*?Session (\d+)',
     'twitterspaces': r'Active Inference ~ Twitter spaces #(\d+)',
     'morphstream': r'MorphStream #?(\d+)\.(\d+)',
     'artstream': r'ArtStream #?(\d+)\.(\d+)',
@@ -237,7 +238,15 @@ def _match_stream(name: str, patterns: dict, is_unique_event_name: bool) -> Even
 def _match_textbook(name: str, patterns: dict) -> EventCategory:
     """Match textbook group patterns."""
     result = EventCategory()
-    
+
+    # Namjoshi 2026 "Fundamentals of Active Inference" reading group
+    if 'fundamentals' in patterns:
+        match = re.search(patterns['fundamentals'], name)
+        if match:
+            result.category = "TextbookGroup/Namjoshi2026/Cohort_1"
+            result.series = f"Session_{match.group(1).zfill(3)}"
+            return result
+
     if 'textbook_parr' in patterns:
         match = re.search(patterns['textbook_parr'], name)
         if match:

--- a/tests/journal_utilities/test_categorizer.py
+++ b/tests/journal_utilities/test_categorizer.py
@@ -12,6 +12,18 @@ class TestCategorizeName:
     """Tests for categorize_name function."""
 
     # Livestream tests
+    def test_fundamentals_session(self):
+        category, series, episode = categorize_name(
+            "Fundamentals of Active Inference (Chapter 6 Session 27) July 14, 2026", False)
+        assert category == "TextbookGroup/Namjoshi2026/Cohort_1"
+        assert series == "Session_027"
+
+    def test_fundamentals_review_session(self):
+        category, series, _ = categorize_name(
+            "Fundamentals of Active Inference (Part 1 review, Session 24) July 3, 2026", False)
+        assert category == "TextbookGroup/Namjoshi2026/Cohort_1"
+        assert series == "Session_024"
+
     def test_livestream_unique_event_name(self):
         category, series, episode = categorize_name("Livestream #057.2", True)
         assert category == "Livestream"


### PR DESCRIPTION
Companion to ActiveInferenceJournal#7. Teaches the categorizer that `Fundamentals of Active Inference … Session N` titles belong at `TextbookGroup/Namjoshi2026/Cohort_1/Session_NNN`, so future sessions (starting with the Session 28 premiere) auto-place via the uncovered pass. Includes tests and a manifest re-enumeration (no delta yet — the premiere isn't on the channel tabs until it airs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjFiMWkgrVy4foGF1Zbax