### PR TITLE
Categorizer: ordinal symposium titles

### DIFF
--- a/src/journal_utilities/youtube/categorizer.py
+++ b/src/journal_utilities/youtube/categorizer.py
@@ -46,6 +46,7 @@ UNIQUE_EVENT_PATTERNS = {
 YOUTUBE_TITLE_PATTERNS = {
     'symposium_2021': r'Prof\. Karl Friston ~ Applied Active Inference Symposium',
     'symposium_2022': r'2nd Applied Active Inference Symposium',
+    'symposium_ordinal': r'(\d+)(?:st|nd|rd|th) Applied Active Inference Symposium \(Part (\d+)',
     'bookstream': r'(Active Inference)? ?(?:~.*~)? ?BookStream #?(\d+)\.(\d+)',
     'social_sciences': r'(Active Inference for (?:the )?Social Sciences 2023|ActInf Social Sciences 2023)',
     'physics_info': r'Physics as Information Processing',
@@ -122,6 +123,15 @@ def _match_symposium(name: str, patterns: dict) -> EventCategory:
             result.series = f"part {match.group(2)}"
             return result
     
+    # "Nth Applied Active Inference Symposium (Part P, ...)" — the 3rd (2023)
+    # onward use ordinal titles; 1st/2021 and 2nd/2022 keep their bespoke rules.
+    if 'symposium_ordinal' in patterns:
+        match = re.search(patterns['symposium_ordinal'], name)
+        if match and int(match.group(1)) >= 3:
+            result.category = f"Applied Active Inference Symposium/{2020 + int(match.group(1))}"
+            result.series = f"part {match.group(2)}"
+            return result
+
     if 'symposium_2021' in patterns:
         match = re.search(patterns['symposium_2021'], name)
         if match:

--- a/tests/journal_utilities/test_categorizer.py
+++ b/tests/journal_utilities/test_categorizer.py
@@ -127,6 +127,18 @@ class TestCategorizeName:
         assert series == "2022 Symposium on Robotics"
         assert episode is None
 
+    def test_symposium_ordinal_2025(self):
+        category, series, _ = categorize_name(
+            "5th Applied Active Inference Symposium (Part 2, Nov 13, 2025) ~ (Full reupload)", False)
+        assert category == "Applied Active Inference Symposium/2025"
+        assert series == "part 2"
+
+    def test_symposium_ordinal_2024(self):
+        category, series, _ = categorize_name(
+            "4th Applied Active Inference Symposium (Part 1, Nov 13, 2024) ~ Full Upload", False)
+        assert category == "Applied Active Inference Symposium/2024"
+        assert series == "part 1"
+
     # Special patterns tests
     def test_social_sciences(self):
         category, series, episode = categorize_name("Active Inference for the Social Sciences 2023", True)


### PR DESCRIPTION
Companion to ActiveInferenceJournal symposium-2025 PR. `Nth Applied Active Inference Symposium (Part P, …)` → `Applied Active Inference Symposium/<2020+N>/part P` for N ≥ 3 (2021/2022 keep bespoke rules). Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjFiMWkgrVy4foGF1Zbax