### PR TITLE
Title-slug naming for Other/ items

### DIFF
--- a/scripts/enrich_metadata.py
+++ b/scripts/enrich_metadata.py
@@ -23,6 +23,7 @@ import logging
 import sys
 from collections import defaultdict
 from pathlib import Path
+from typing import Optional
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "src"))
@@ -101,6 +102,16 @@ def manifest_part(video: dict) -> dict:
     return part
 
 
+def find_secondary_item(vid: str, canonical: str, items: dict) -> Optional[str]:
+    """Locate the non-canonical item carrying this video id (slug-named Other/ dup)."""
+    for rel, entry in items.items():
+        if rel == canonical:
+            continue
+        if any(p.get("video_id") == vid for p in entry["meta"].get("parts", [])):
+            return rel
+    return None
+
+
 def process_split_files(split_dir: Path, items: dict, manifest: dict, report: dict) -> dict[str, dict]:
     """Parse *_split.txt files -> {item_rel: {enrichment, fill_parts}}; mark Other/ duplicates."""
     pending: dict[str, dict] = {}
@@ -123,8 +134,8 @@ def process_split_files(split_dir: Path, items: dict, manifest: dict, report: di
              "parts_filled": bool(fill)}
         )
 
-        duplicate = f"Other/{result.video_id}"
-        if duplicate in items:
+        duplicate = find_secondary_item(result.video_id, target, items)
+        if duplicate:
             pending[duplicate] = {
                 "enrichment": {"duplicate_of": target, "enriched_from": ["split_file"]},
                 "fill_parts": None,
@@ -192,8 +203,8 @@ def process_curated_parts(items: dict, manifest: dict, pending: dict, report: di
             "replace_parts": True,
             "overrides": {"sessions": CURATED_SESSIONS[rel]} if rel in CURATED_SESSIONS else {},
         }
-        duplicate = f"Other/{vid}"
-        if duplicate in items:
+        duplicate = find_secondary_item(vid, rel, items)
+        if duplicate:
             pending[duplicate] = {
                 "enrichment": {"duplicate_of": rel, "enriched_from": ["curated"]},
                 "fill_parts": None,

--- a/scripts/refactor_journal.py
+++ b/scripts/refactor_journal.py
@@ -322,7 +322,12 @@ def _build_uncovered(journal: Path, out_dir: Path, titles: dict, item_paths: lis
         if cat and ser:
             series, item = cat, ser
         else:
-            series, item = "Other", vid
+            from journal_utilities.utils.naming import slugify_title
+
+            series = "Other"
+            item = slugify_title(v.get("title", "")) or vid
+            if (out_dir / SRC_PREFIX / series / item).exists():
+                item = f"{item}_{vid}"
         dest = out_dir / SRC_PREFIX / series / item
         dest.mkdir(parents=True, exist_ok=True)
         meta = {

--- a/src/journal_utilities/utils/naming.py
+++ b/src/journal_utilities/utils/naming.py
@@ -1,0 +1,29 @@
+"""
+Deterministic, filesystem-safe names derived from video titles.
+
+Used for journal items that have no series numbering (Other/ one-offs):
+the slug is generated once at item creation and recorded as the item name;
+the video id in metadata.json parts[] stays authoritative for all lookups.
+"""
+
+import re
+import unicodedata
+
+MAX_SLUG_LEN = 60
+
+
+def slugify_title(title: str, max_len: int = MAX_SLUG_LEN) -> str:
+    """
+    Turn a video title into a stable directory-safe slug.
+
+    ASCII letters/digits/underscore only (checkout-safe on every platform),
+    accents folded, '&' becomes 'and', capped at max_len on a word boundary.
+    Returns '' for titles with no usable characters — callers fall back to
+    the video id.
+    """
+    text = unicodedata.normalize("NFKD", title or "").replace("&", " and ")
+    text = "".join(c for c in text if not unicodedata.combining(c))
+    text = re.sub(r"[^A-Za-z0-9]+", "_", text).strip("_")
+    if len(text) > max_len:
+        text = text[:max_len].rsplit("_", 1)[0]
+    return text.strip("_")

--- a/tests/journal_utilities/test_naming.py
+++ b/tests/journal_utilities/test_naming.py
@@ -1,0 +1,26 @@
+"""Tests for journal_utilities.utils.naming."""
+
+from journal_utilities.utils.naming import slugify_title
+
+
+class TestSlugifyTitle:
+    def test_basic(self):
+        assert slugify_title("Introduction to recording & livestreaming with OBS") == \
+            "Introduction_to_recording_and_livestreaming_with_OBS"
+
+    def test_accents_fold(self):
+        assert slugify_title("Inês Hipólito: “Dysfunctional Markov Blankets“") == \
+            "Ines_Hipolito_Dysfunctional_Markov_Blankets"
+
+    def test_length_cap_on_word_boundary(self):
+        slug = slugify_title("A" + " very" * 30 + " long title")
+        assert len(slug) <= 60
+        assert not slug.endswith("_")
+
+    def test_deterministic(self):
+        title = "Karl Friston \"Active inference and deep temporal models\" 23.09.19"
+        assert slugify_title(title) == slugify_title(title)
+
+    def test_empty_and_symbol_only(self):
+        assert slugify_title("") == ""
+        assert slugify_title("~ ~ ~") == ""


### PR DESCRIPTION
Companion to the journal other-title-slugs PR: `slugify_title` in `utils/naming` (tested), slug-based naming in the uncovered pass with collision suffix, slug-proof duplicate lookups in enrichment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjFiMWkgrVy4foGF1Zbax