### PR TITLE
Journal-driven WhisperX transcription (replaces SurrealDB queue)

### DIFF
--- a/scripts/transcribe_worklist.py
+++ b/scripts/transcribe_worklist.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Transcribe missing journal items with WhisperX + speaker diarization —
+journal-driven, no database.
+
+The worklist is derived from the journal repo exactly like
+transcription_status.py: an item needs transcription when it lacks
+transcript.txt (future-dated/scheduled items are skipped). For each part
+video: download a WAV (cookie-free yt-dlp), transcribe + diarize with the
+existing TranscriptionService, then write speaker-labeled transcript.txt
+(and transcript.json) into the journal item — "## <video_id>" sections for
+multi-part items. Speaker labels are SPEAKER_NN; mapping them to names
+remains the human step (edit the journal file directly — it is canonical).
+
+Resumable: WAVs and per-video WhisperX outputs are cached in --work-dir and
+skipped on re-run; items whose parts are all cached just get journal writes.
+
+Usage:
+    python scripts/transcribe_worklist.py                 # dry run: show plan
+    python scripts/transcribe_worklist.py --run           # transcribe everything
+    python scripts/transcribe_worklist.py --run --max-videos 2
+"""
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "scripts"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("transcribe_worklist")
+
+SRC_PREFIX = "data/video/activeinferenceinstitute"
+
+
+def build_worklist(journal: Path, no_video: list = None) -> list[dict]:
+    """Items lacking transcript.txt (excluding duplicates and future streams).
+
+    Items with no known video id (private/unlisted content) are appended to
+    ``no_video`` — their audio must be sourced manually.
+    """
+    from transcription_status import item_status
+
+    no_video = no_video if no_video is not None else []
+    today = date.today().isoformat()
+    work = []
+    for meta_path in sorted((journal / SRC_PREFIX).rglob("metadata.json")):
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        if meta.get("duplicate_of"):
+            continue
+        if item_status(meta_path.parent) != "missing":
+            continue
+        dates = [meta.get("date", "")] + [p.get("date", "") for p in meta.get("parts", [])]
+        if max(filter(None, dates), default="") > today:
+            continue  # scheduled — nothing to transcribe yet
+        rel = str(meta_path.parent.relative_to(journal / SRC_PREFIX))
+        vids = [p["video_id"] for p in meta.get("parts", []) if p.get("video_id")]
+        if vids:
+            work.append({"rel": rel, "dir": meta_path.parent, "vids": vids})
+        else:
+            no_video.append(rel)
+    return work
+
+
+def download_wav(vid: str, wav_dir: Path) -> Path:
+    wav = wav_dir / f"{vid}.wav"
+    if wav.exists():
+        logger.info("wav cached: %s", wav.name)
+        return wav
+    logger.info("downloading audio: %s", vid)
+    subprocess.run(
+        ["yt-dlp", "-x", "--audio-format", "wav", "-o", str(wav_dir / f"{vid}.%(ext)s"),
+         "--", f"https://www.youtube.com/watch?v={vid}"],
+        check=True)
+    if not wav.exists():
+        raise FileNotFoundError(f"yt-dlp did not produce {wav}")
+    return wav
+
+
+def write_journal_transcript(item_dir: Path, vids: list[str], out_dir: Path) -> None:
+    """Assemble journal transcript.txt/.json from cached per-video outputs."""
+    sections, seg_blocks = [], []
+    for vid in vids:
+        txt = (out_dir / f"{vid}.simple.txt").read_text(encoding="utf-8").strip()
+        sections.append(txt if len(vids) == 1 else f"## {vid}\n\n{txt}")
+        segments = json.loads((out_dir / f"{vid}.simple.json").read_text(encoding="utf-8"))
+        seg_blocks.append({"video_id": vid, "segments": segments})
+    (item_dir / "transcript.txt").write_text("\n\n".join(sections) + "\n", encoding="utf-8")
+    (item_dir / "transcript.json").write_text(
+        json.dumps(seg_blocks, ensure_ascii=False), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--journal", type=Path, default=REPO.parent / "ActiveInferenceJournal")
+    parser.add_argument("--work-dir", type=Path, default=REPO / "data/output/whisperx",
+                        help="cache for WAVs and per-video WhisperX outputs")
+    parser.add_argument("--run", action="store_true", help="transcribe (default: dry-run plan)")
+    parser.add_argument("--max-videos", type=int, default=0, help="bound this run")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--batch-size", type=int, default=48)
+    parser.add_argument("--compute-type", default="float16",
+                        help="float16, or int8 if low on GPU memory")
+    args = parser.parse_args()
+
+    load_dotenv(REPO / ".env")
+    import os
+
+    no_video: list = []
+    worklist = build_worklist(args.journal, no_video)
+    total_vids = sum(len(w["vids"]) for w in worklist)
+    print(f"worklist: {len(worklist)} items / {total_vids} videos")
+    for w in worklist:
+        cached = sum(1 for v in w["vids"] if (args.work_dir / f"{v}.simple.txt").exists())
+        print(f"  {w['rel']}  ({len(w['vids'])} video(s), {cached} cached)")
+    if no_video:
+        print(f"no known video ({len(no_video)} items — audio must be sourced manually):")
+        for rel in no_video:
+            print(f"  {rel}")
+    if not args.run:
+        print("\ndry run — pass --run to transcribe")
+        return 0
+    if not worklist:
+        return 0
+
+    hf_token = os.getenv("HF_TOKEN") or os.getenv("HUGGINGFACE_TOKEN")
+    if not hf_token:
+        logger.error("HF_TOKEN/HUGGINGFACE_TOKEN missing from .env — required for diarization")
+        return 1
+
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    wav_dir = args.work_dir / "wav"
+    wav_dir.mkdir(exist_ok=True)
+
+    # Heavy import deferred so dry runs work without GPU deps loaded.
+    from journal_utilities.transcribe.transcribe import TranscriptionService
+
+    service = None  # lazy: skip model load when everything needed is cached
+    done = 0
+    for item in worklist:
+        try:
+            for vid in item["vids"]:
+                if (args.work_dir / f"{vid}.simple.txt").exists():
+                    logger.info("transcript cached: %s", vid)
+                    continue
+                if args.max_videos and done >= args.max_videos:
+                    print(f"\nreached --max-videos={args.max_videos}; run again to continue")
+                    return 0
+                wav = download_wav(vid, wav_dir)
+                if service is None:
+                    logger.info("loading WhisperX models (%s, %s)", args.device, args.compute_type)
+                    service = TranscriptionService(hf_token, args.device,
+                                                   args.batch_size, args.compute_type)
+                logger.info("transcribing %s (%s)", vid, item["rel"])
+                service.transcribe(str(args.work_dir), str(wav))
+                done += 1
+            if all((args.work_dir / f"{v}.simple.txt").exists() for v in item["vids"]):
+                write_journal_transcript(item["dir"], item["vids"], args.work_dir)
+                logger.info("journal transcript written: %s", item["rel"])
+        except subprocess.CalledProcessError as exc:
+            logger.error("audio download failed for %s: %s — skipping item", item["rel"], exc)
+        except (IOError, RuntimeError) as exc:
+            logger.error("transcription failed for %s: %s — skipping item", item["rel"], exc)
+
+    print("\ndone — review the journal diff, then commit. Remember:")
+    print("  1. speaker labels are SPEAKER_NN; map to names by editing the journal files")
+    print("  2. regenerate indexes + validate before committing (see SCHEMA.md)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/journal_utilities/test_transcribe_worklist.py
+++ b/tests/journal_utilities/test_transcribe_worklist.py
@@ -1,0 +1,61 @@
+"""Tests for scripts/transcribe_worklist.py (no GPU, no network)."""
+
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+from transcribe_worklist import SRC_PREFIX, build_worklist, write_journal_transcript
+
+
+def _make_item(root: Path, rel: str, vids: list[str], transcript: bool = False,
+               date: str = "", dup: str = "") -> None:
+    item = root / SRC_PREFIX / rel
+    item.mkdir(parents=True)
+    meta = {"series": rel.split("/")[0], "item": rel.split("/")[-1],
+            "parts": [{"video_id": v} for v in vids]}
+    if date:
+        meta["date"] = date
+    if dup:
+        meta["duplicate_of"] = dup
+    (item / "metadata.json").write_text(json.dumps(meta))
+    if transcript:
+        (item / "transcript.txt").write_text("existing")
+
+
+class TestBuildWorklist:
+    def test_selects_only_missing_past_items(self, tmp_path):
+        _make_item(tmp_path, "A/needs_it", ["vid00000001"])
+        _make_item(tmp_path, "A/has_transcript", ["vid00000002"], transcript=True)
+        _make_item(tmp_path, "A/future", ["vid00000003"], date="2199-01-01")
+        _make_item(tmp_path, "Other/dup", ["vid00000001"], dup="A/needs_it")
+        work = build_worklist(tmp_path)
+        assert [w["rel"] for w in work] == ["A/needs_it"]
+        assert work[0]["vids"] == ["vid00000001"]
+
+
+class TestWriteJournalTranscript:
+    def _cache(self, out_dir: Path, vid: str, text: str) -> None:
+        (out_dir / f"{vid}.simple.txt").write_text(text)
+        (out_dir / f"{vid}.simple.json").write_text(
+            json.dumps([{"speaker": "SPEAKER_00", "text": text}]))
+
+    def test_single_part_plain(self, tmp_path):
+        item, out = tmp_path / "item", tmp_path / "out"
+        item.mkdir(), out.mkdir()
+        self._cache(out, "vid00000001", "SPEAKER_00:\nhello")
+        write_journal_transcript(item, ["vid00000001"], out)
+        assert (item / "transcript.txt").read_text() == "SPEAKER_00:\nhello\n"
+        assert json.loads((item / "transcript.json").read_text())[0]["video_id"] == "vid00000001"
+
+    def test_multi_part_sections(self, tmp_path):
+        item, out = tmp_path / "item", tmp_path / "out"
+        item.mkdir(), out.mkdir()
+        self._cache(out, "vidaaaaaaaa", "part one")
+        self._cache(out, "vidbbbbbbbb", "part two")
+        write_journal_transcript(item, ["vidaaaaaaaa", "vidbbbbbbbb"], out)
+        text = (item / "transcript.txt").read_text()
+        assert "## vidaaaaaaaa" in text and "## vidbbbbbbbb" in text
+        assert len(json.loads((item / "transcript.json").read_text())) == 2


### PR DESCRIPTION
`scripts/transcribe_worklist.py`: the transcription queue now derives from the journal repo (missing `transcript.txt`, duplicates and scheduled streams excluded) instead of SurrealDB session flags. Downloads WAVs cookie-free, reuses the existing `TranscriptionService` (WhisperX large-v3 + alignment + pyannote diarization), caches per-video outputs for resumability, and writes speaker-labeled `transcript.txt`/`transcript.json` directly into journal items (`## <video_id>` sections for multi-part). Items with no known video id (private/unlisted) are reported for manual audio sourcing.

Dry-run by default; smoke-tested end-to-end on CUDA (TITAN RTX). Speaker-name mapping stays the human step — edit the journal files, they're canonical.

Current worklist: 6 videos (5 Fundamentals sessions + GuestStream_128), 12 items need manual audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjFiMWkgrVy4foGF1Zbax