### PR TITLE
Preload cuDNN/cuBLAS for the WhisperX encoder

### DIFF
--- a/scripts/transcribe_worklist.py
+++ b/scripts/transcribe_worklist.py
@@ -141,6 +141,20 @@ def main() -> int:
     wav_dir = args.work_dir / "wav"
     wav_dir.mkdir(exist_ok=True)
 
+    # ctranslate2 dlopens cuDNN by soname; pip-installed nvidia wheels are not
+    # on the loader path, so preload them (RTLD_GLOBAL) or the whisper encoder
+    # aborts with "Unable to load libcudnn_cnn.so.9".
+    import ctypes
+    import site
+
+    for sp in site.getsitepackages():
+        for pattern in ("nvidia/cublas/lib/libcublas*.so*", "nvidia/cudnn/lib/libcudnn*.so.9"):
+            for lib in sorted(Path(sp).glob(pattern)):
+                try:
+                    ctypes.CDLL(str(lib), mode=ctypes.RTLD_GLOBAL)
+                except OSError:
+                    pass
+
     # Heavy import deferred so dry runs work without GPU deps loaded.
     from journal_utilities.transcribe.transcribe import TranscriptionService
 


### PR DESCRIPTION
ctranslate2 dlopens `libcudnn_cnn.so.9` by soname; pip's nvidia wheels aren't on the loader path, so the whisper encoder aborted (SIGABRT) on real speech — synthetic VAD-empty audio never reached the encoder, masking it. Preload with RTLD_GLOBAL before the heavy import. Verified end-to-end on real audio with diarization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjFiMWkgrVy4foGF1Zbax